### PR TITLE
Create TarEntry objects without requiring File objects

### DIFF
--- a/src/main/java/org/kamranzafar/jtar/TarEntry.java
+++ b/src/main/java/org/kamranzafar/jtar/TarEntry.java
@@ -44,6 +44,22 @@ public class TarEntry {
 		this.parseTarHeader(headerBuf);
 	}
 
+	/**
+	 * Constructor to create an entry from an existing TarHeader object.
+	 * 
+	 * This method is useful to add new entries programmatically (e.g. for
+	 * adding files or directories that do not exist in the file system).
+	 * 
+	 * @param header
+	 * 
+	 * @see TarHeader#createFileHeader(String, long, long)
+	 * @see TarHeader#createDirHeader(String, long)
+	 */
+    public TarEntry(TarHeader header) {
+        this.file = null;
+        this.header = header;
+    }	
+	
 	public boolean equals(TarEntry it) {
 		return this.header.name.toString().equals(it.header.name.toString());
 	}

--- a/src/main/java/org/kamranzafar/jtar/TarHeader.java
+++ b/src/main/java/org/kamranzafar/jtar/TarHeader.java
@@ -17,6 +17,8 @@
 
 package org.kamranzafar.jtar;
 
+import java.io.File;
+
 /**
  * Header
  * 
@@ -192,6 +194,80 @@ public class TarHeader {
         }
 
         return offset + length;
+    }
+
+    /**
+     * Creates a new header for a file entry.
+     * 
+     * This method is useful for creating entries that do not correspond to a
+     * file. 
+     * 
+     * @param fileName File name
+     * @param fileSize File size in bytes
+     * @param modTime Last modification time in numeric Unix time format
+     * 
+     * @return 
+     */
+    public static TarHeader createFileHeader(String fileName, long fileSize, long modTime) {
+        String name = fileName;
+        TarHeader header  = new TarHeader();
+        name = name.replace(File.separatorChar, '/');
+
+        if (name.startsWith("/"))
+            name = name.substring(1);
+
+        header.linkName = new StringBuffer("");
+
+        header.name = new StringBuffer(name);
+
+        header.mode = 0100644;
+        header.linkFlag = TarHeader.LF_NORMAL;
+        header.size = fileSize;
+
+        header.modTime = modTime;
+        header.checkSum = 0;
+        header.devMajor = 0;
+        header.devMinor = 0;
+        
+        return header;
+    }
+    
+    /**
+     * Creates a new header for a directory entry.
+     * 
+     * This method is useful for creating entries that do not correspond to
+     * a directory in the file system.
+     * 
+     * @param fileName Directory name
+     * @param modTime Last modification time in numeric Unix time format
+     * 
+     * @return 
+     */
+    public static TarHeader createDirHeader(String dirName, long modTime) {
+        String name = dirName;
+        TarHeader header  = new TarHeader();
+        name = name.replace(File.separatorChar, '/');
+
+        if (name.startsWith("/"))
+            name = name.substring(1);
+
+        header.linkName = new StringBuffer("");
+
+        header.name = new StringBuffer(name);
+
+        header.mode = 040755;
+        header.linkFlag = TarHeader.LF_DIR;
+        if (header.name.charAt(header.name.length() - 1) != '/') {
+            header.name.append("/");
+        }
+        header.size = 0;
+
+        header.modTime = modTime;
+        header.checkSum = 0;
+        header.devMajor = 0;
+        header.devMinor = 0;
+        
+        return header;
     }
 
 }

--- a/src/test/java/org/kamranzafar/jtar/JTarTest.java
+++ b/src/test/java/org/kamranzafar/jtar/JTarTest.java
@@ -28,6 +28,7 @@ import java.util.zip.GZIPInputStream;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import static org.junit.Assert.*;
 
 @RunWith(JUnit4.class)
 public class JTarTest {
@@ -182,5 +183,30 @@ public class JTarTest {
 
 			origin.close();
 		}
+	}
+	
+	@Test
+	public void fileEntry() throws IOException {
+	    
+	    String fileName = "file.txt";
+	    long fileSize = 14523;
+	    long modTime = System.currentTimeMillis() / 1000;
+	    
+	    // Create a header object and check the fields
+	    TarHeader fileHeader = TarHeader.createFileHeader(fileName, fileSize, modTime);
+	    assertEquals(fileName, fileHeader.name.toString());
+	    assertEquals(TarHeader.LF_NORMAL, fileHeader.linkFlag);
+	    assertEquals(fileSize, fileHeader.size);
+	    assertEquals(modTime, fileHeader.modTime);
+
+	    // Create an entry from the header
+	    TarEntry fileEntry = new TarEntry(fileHeader);
+	    assertEquals(fileName, fileEntry.getName());
+	    
+	    // Write the header into a buffer, create it back and compare them
+	    byte[] headerBuf = new byte[TarConstants.HEADER_BLOCK];
+	    fileEntry.writeEntryHeader( headerBuf );
+	    TarEntry createdEntry = new TarEntry(headerBuf);
+	    assertTrue(fileEntry.equals(createdEntry));
 	}
 }


### PR DESCRIPTION
Hello,

I added a couple of methods for creating TarEntry objects that do not correspond to a file in the file system. I did it since I wanted to create entries for objects that were generated by my program (and I did not want to write temporary files for them).

I added two static methods to TarHeader to create headers for files and directories and I added another constructor to TarEntry, so that they can be used. I also included a simple test case.

Thanks for creating jtar and please let me know if you have any comments.
