### PR TITLE
Additional handling of Files in TarEntries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ target/
 .settings/
 .project
 .classpath
-
+.idea/
+*.iml

--- a/src/main/java/org/kamranzafar/jtar/TarEntry.java
+++ b/src/main/java/org/kamranzafar/jtar/TarEntry.java
@@ -136,6 +136,10 @@ public class TarEntry {
 		return this.file;
 	}
 
+    void setFile(File file){
+        this.file = file;
+    }
+
 	public long getSize() {
 		return header.size;
 	}

--- a/src/main/java/org/kamranzafar/jtar/TarInputStream.java
+++ b/src/main/java/org/kamranzafar/jtar/TarInputStream.java
@@ -17,9 +17,7 @@
 
 package org.kamranzafar.jtar;
 
-import java.io.FilterInputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 
 /**
  * @author Kamran Zafar
@@ -145,6 +143,7 @@ public class TarInputStream extends FilterInputStream {
 
 		if (!eof) {
 			currentEntry = new TarEntry(header);
+            readCurrentEntryIntoFile();
 		}
 
 		return currentEntry;
@@ -157,7 +156,35 @@ public class TarInputStream extends FilterInputStream {
 	public long getCurrentOffset() {
 		return bytesRead;
 	}
-	
+
+    /**
+     * Reads the contents of the current entry's file into a File object
+     * @throws IOException
+     */
+    protected void readCurrentEntryIntoFile() throws IOException {
+
+        //Create a spot on disk to store the data
+        File tempFile = File.createTempFile("jtar",".tmp");
+        tempFile.deleteOnExit();
+
+        int count;
+        byte data[] = new byte[2048];
+
+        try(FileOutputStream fos = new FileOutputStream(tempFile);
+            BufferedOutputStream dest = new BufferedOutputStream(fos)) {
+
+            while ((count = this.read(data,0,1)) != -1) {
+                dest.write(data, 0, count);
+            }
+
+            dest.flush();
+        }
+
+        if(currentEntry != null){
+            currentEntry.setFile(tempFile);
+        }
+    }
+
 	/**
 	 * Closes the current tar entry
 	 * 

--- a/src/main/java/org/kamranzafar/jtar/TarUtils.java
+++ b/src/main/java/org/kamranzafar/jtar/TarUtils.java
@@ -17,7 +17,9 @@
 
 package org.kamranzafar.jtar;
 
-import java.io.File;
+import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Kamran
@@ -93,4 +95,22 @@ public class TarUtils {
 
 		return tmp.toString();
 	}
+
+    /**
+     * Returns a list of Files in a given tar archive.
+     *
+     * @param tarFile the tar archive File
+     * @return a list of Files in the tarFile parameter
+     * @throws IOException if there is an error reading the archive
+     */
+    public static List<TarEntry> getAllEntriesFromTar(File tarFile) throws IOException{
+        TarInputStream tis = new TarInputStream(new BufferedInputStream(new FileInputStream(tarFile)));
+        List<TarEntry> entries = new ArrayList<>();
+        TarEntry entry;
+        while((entry = tis.getNextEntry()) != null) {
+            entries.add(entry);
+        }
+
+        return entries;
+    }
 }

--- a/src/test/java/org/kamranzafar/jtar/JTarAppendTest.java
+++ b/src/test/java/org/kamranzafar/jtar/JTarAppendTest.java
@@ -113,7 +113,8 @@ public class JTarAppendTest {
 				int count;
 				byte data[] = new byte[2048];
 				try (BufferedOutputStream dest = new BufferedOutputStream(new FileOutputStream(outDir + "/" + entry.getName()))) {
-					while ((count = in.read(data)) != -1) {
+					FileInputStream fis = new FileInputStream(entry.getFile());
+                    while ((count = fis.read(data)) != -1) {
 						dest.write(data, 0, count);
 					}
 				}

--- a/src/test/java/org/kamranzafar/jtar/TarUtilsTest.java
+++ b/src/test/java/org/kamranzafar/jtar/TarUtilsTest.java
@@ -1,0 +1,33 @@
+package org.kamranzafar.jtar;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+/**
+ * Author: Phillip Johnson
+ * Date: 5/6/14
+ */
+public class TarUtilsTest {
+
+    @Test
+    public void allFilesAreLoadedIntoCollection() throws IOException{
+        List<TarEntry> entries = TarUtils.getAllEntriesFromTar(new File("src/test/resources/tartest.tar"));
+        assertTrue(entries.size()==6);
+        List<String> fileNames = new ArrayList<>();
+        for(TarEntry entry : entries){
+            fileNames.add(entry.getName());
+        }
+        //Verify we saved each of the distinct entries
+        assertTrue(fileNames.contains("tartest/one"));
+        assertTrue(fileNames.contains("tartest/two"));
+        assertTrue(fileNames.contains("tartest/three"));
+        assertTrue(fileNames.contains("tartest/four"));
+        assertTrue(fileNames.contains("tartest/five"));
+        assertTrue(fileNames.contains("tartest/six"));
+    }
+}


### PR DESCRIPTION
I was using your library today and there was some functionality that I felt would make the library a bit easier to use. Thanks for your effort  in creating this utility, it doesn't seem like there is much else out there except for the bloated Apache library. The commit changes below are pretty self-explanatory. Let me know what you think.
- When iterating over the tar stream, each Entry will get a reference to its associated File.
- Added a utility method for easily retrieving all of the TarEntries in a given archive.
- Updated/added unit tests accordingly.

Note that some small tweaks were required for the unit tests because the bytesRead count now must also include the bytes of the file just read.
