### PR TITLE
Replace StringBuffer usages with StringBuilder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.8.1</version>
+			<version>4.13.1</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/org/kamranzafar/jtar/TarEntry.java
+++ b/src/main/java/org/kamranzafar/jtar/TarEntry.java
@@ -162,8 +162,7 @@ public class TarEntry {
 			if (header.linkFlag == TarHeader.LF_DIR)
 				return true;
 
-			if (header.name.toString().endsWith("/"))
-				return true;
+			return header.name.toString().endsWith("/");
 		}
 
 		return false;
@@ -183,8 +182,8 @@ public class TarEntry {
 	public long computeCheckSum(byte[] buf) {
 		long sum = 0;
 
-		for (int i = 0; i < buf.length; ++i) {
-			sum += 255 & buf[i];
+		for (byte b : buf) {
+			sum += 255 & b;
 		}
 
 		return sum;
@@ -220,8 +219,9 @@ public class TarEntry {
 		offset = Octal.getOctalBytes(header.devMinor, outbuf, offset, TarHeader.USTAR_DEVLEN);
 		offset = TarHeader.getNameBytes(header.namePrefix, outbuf, offset, TarHeader.USTAR_FILENAME_PREFIX);
 
-		for (; offset < outbuf.length;)
+		while (offset < outbuf.length) {
 			outbuf[offset++] = 0;
+		}
 
 		long checkSum = this.computeCheckSum(outbuf);
 

--- a/src/main/java/org/kamranzafar/jtar/TarEntry.java
+++ b/src/main/java/org/kamranzafar/jtar/TarEntry.java
@@ -1,18 +1,18 @@
-/**
- * Copyright 2012 Kamran Zafar 
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
- * You may obtain a copy of the License at 
- * 
- *      http://www.apache.org/licenses/LICENSE-2.0 
- * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
- * limitations under the License. 
- * 
+/*
+ * Copyright 2012 Kamran Zafar
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
  */
 
 package org.kamranzafar.jtar;

--- a/src/main/java/org/kamranzafar/jtar/TarEntry.java
+++ b/src/main/java/org/kamranzafar/jtar/TarEntry.java
@@ -87,7 +87,7 @@ public class TarEntry {
 	}
 
 	public void setName(String name) {
-		header.name = new StringBuffer(name);
+		header.name = new StringBuilder(name);
 	}
 
 	public int getUserId() {
@@ -111,7 +111,7 @@ public class TarEntry {
 	}
 
 	public void setUserName(String userName) {
-		header.userName = new StringBuffer(userName);
+		header.userName = new StringBuilder(userName);
 	}
 
 	public String getGroupName() {
@@ -119,7 +119,7 @@ public class TarEntry {
 	}
 
 	public void setGroupName(String groupName) {
-		header.groupName = new StringBuffer(groupName);
+		header.groupName = new StringBuilder(groupName);
 	}
 
 	public void setIds(int userId, int groupId) {

--- a/src/main/java/org/kamranzafar/jtar/TarHeader.java
+++ b/src/main/java/org/kamranzafar/jtar/TarHeader.java
@@ -106,7 +106,7 @@ public class TarHeader {
 	public static final int USTAR_FILENAME_PREFIX = 155;
 
 	// Header values
-	public StringBuffer name;
+	public StringBuilder name;
 	public int mode;
 	public int userId;
 	public int groupId;
@@ -114,19 +114,19 @@ public class TarHeader {
 	public long modTime;
 	public int checkSum;
 	public byte linkFlag;
-	public StringBuffer linkName;
-	public StringBuffer magic; // ustar indicator and version
-	public StringBuffer userName;
-	public StringBuffer groupName;
+	public StringBuilder linkName;
+	public StringBuilder magic; // ustar indicator and version
+	public StringBuilder userName;
+	public StringBuilder groupName;
 	public int devMajor;
 	public int devMinor;
-	public StringBuffer namePrefix;
+	public StringBuilder namePrefix;
 
 	public TarHeader() {
-		this.magic = new StringBuffer(TarHeader.USTAR_MAGIC);
+		this.magic = new StringBuilder(TarHeader.USTAR_MAGIC);
 
-		this.name = new StringBuffer();
-		this.linkName = new StringBuffer();
+		this.name = new StringBuilder();
+		this.linkName = new StringBuilder();
 
 		String user = System.getProperty("user.name", "");
 
@@ -135,9 +135,9 @@ public class TarHeader {
 
 		this.userId = 0;
 		this.groupId = 0;
-		this.userName = new StringBuffer(user);
-		this.groupName = new StringBuffer("");
-		this.namePrefix = new StringBuffer();
+		this.userName = new StringBuilder(user);
+		this.groupName = new StringBuilder("");
+		this.namePrefix = new StringBuilder();
 	}
 
 	/**
@@ -151,8 +151,8 @@ public class TarHeader {
 	 *            The number of header bytes to parse.
 	 * @return The header's entry name.
 	 */
-	public static StringBuffer parseName(byte[] header, int offset, int length) {
-		StringBuffer result = new StringBuffer(length);
+	public static StringBuilder parseName(byte[] header, int offset, int length) {
+		StringBuilder result = new StringBuilder(length);
 
 		int end = offset + length;
 		for (int i = offset; i < end; ++i) {
@@ -175,7 +175,7 @@ public class TarHeader {
 	 *            The number of header bytes to parse.
 	 * @return The number of bytes in a header's entry name.
 	 */
-	public static int getNameBytes(StringBuffer name, byte[] buf, int offset, int length) {
+	public static int getNameBytes(StringBuilder name, byte[] buf, int offset, int length) {
 		int i;
 
 		for (i = 0; i < length && i < name.length(); ++i) {
@@ -207,14 +207,14 @@ public class TarHeader {
 		name = TarUtils.trim(name.replace(File.separatorChar, '/'), '/');
 
 		TarHeader header = new TarHeader();
-		header.linkName = new StringBuffer("");
+		header.linkName = new StringBuilder("");
 		header.mode = permissions;
 
 		if (name.length() > 100) {
-			header.namePrefix = new StringBuffer(name.substring(0, name.lastIndexOf('/')));
-			header.name = new StringBuffer(name.substring(name.lastIndexOf('/') + 1));
+			header.namePrefix = new StringBuilder(name.substring(0, name.lastIndexOf('/')));
+			header.name = new StringBuilder(name.substring(name.lastIndexOf('/') + 1));
 		} else {
-			header.name = new StringBuffer(name);
+			header.name = new StringBuilder(name);
 		}
 		if (dir) {
 			header.linkFlag = TarHeader.LF_DIR;

--- a/src/main/java/org/kamranzafar/jtar/TarUtils.java
+++ b/src/main/java/org/kamranzafar/jtar/TarUtils.java
@@ -71,7 +71,7 @@ public class TarUtils {
 	}
 
 	public static String trim(String s, char c) {
-		StringBuffer tmp = new StringBuffer(s);
+		StringBuilder tmp = new StringBuilder(s);
 		for (int i = 0; i < tmp.length(); i++) {
 			if (tmp.charAt(i) != c) {
 				break;


### PR DESCRIPTION
For better thread safety going forward. Replace usage of StringBuffer with StringBuilder.

Also, while working in `TarEntry.java` I took the liberty of fixing the danling javadoc comment, switched to the more modern enhanced for loop where applicable and changed the below for loop to a while loop for better readability.

> -  for (; offset < outbuf.length;)
> + while (offset < outbuf.length) 

